### PR TITLE
Fix broken RISK_ANALYSIS.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These frameworks strengthen the case for publiccode.yml extensions: sovereignty 
 
 **See [ROADMAP.md](ROADMAP.md) for an illustrative phased implementation plan** - to work towards the proposal by building momentum with achievable milestones, and address critical risks.
 
-**See [RISK_ANALYSIS.md](RISK_ANALYSIS) for a systematic examination of risks to the proposal** - each risk includes an assessment of likelihood and impact, plus potential mitigations.
+**See [RISK_ANALYSIS.md](RISK_ANALYSIS.md) for a systematic examination of risks to the proposal** - each risk includes an assessment of likelihood and impact, plus potential mitigations.
 
 ---
 


### PR DESCRIPTION
Missing .md extension on the link.