### PR TITLE
Sovereignty check

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -22,6 +22,12 @@ An automated security audit tool that checks open source projects for common sec
 **REUSE**
 A standard created by the Free Software Foundation Europe (FSFE) for making per-file licensing transparent. Every source file declares its license, making compliance auditable by machines.
 
+**Vendor Lock-in (or Vendor Lockin)**
+A situation where a customer becomes dependent on a single vendor and cannot switch to alternatives without significant cost, effort, or loss of functionality. For open source software, lock-in can occur at the architectural level—for example, when a project requires proprietary cloud features (e.g., AWS RDS Aurora-specific extensions, Azure Cosmos DB functionality) that are unavailable in open-source equivalents. Declared in [Improvement 8: Platform Lock-in Declaration](PROPOSAL.md#improvement-8-platform-lock-in-declaration-proposed).
+
+**Platform Lock-in**
+A specific form of vendor lock-in where software requires deployment on a proprietary platform (e.g., AWS, Azure, Google Cloud) or requires platform-specific features not available in open-source alternatives. Projects should declare required platforms and lock-in risks in publiccode.yml so procurement offices and Sovereignty Checks can assess true portability.
+
 **Cyber Resilience Act (CRA)**
 An EU regulation establishing requirements for open source software security and liability. Introduces the "open source software steward"—an organization responsible for maintaining security and handling vulnerabilities in critical software. Requires stewards to publish security policies and software bill of materials (SBOMs).
 
@@ -118,10 +124,14 @@ A database or service that tracks specific information about projects:
 
 - **Credit Registry**: Tracks who contributes and how much
 - **Usage Registry**: Tracks which organizations use which software
+- **Assessment Registry**: Publishes results of compliance or sovereignty assessments conducted by regional authorities (e.g., ZenDiS Sovereignty Check results from Germany, DPI validation results from India). See [Assessment Registry API](PROPOSAL.md#assessment-registry-api-proposed).
 - **Package Registry**: Hosts downloadable packages (npm, PyPI, Maven, etc.)
 
 **API**
 Application Programming Interface. A standard way for different software systems to request and share data. Think of it as a plug that any compatible tool can use.
+
+**Sovereignty Check**
+A formal assessment process that evaluates whether software meets specific digital sovereignty requirements. Examples: ZenDiS Sovereignty Check (Germany) evaluates whether solutions meet digital sovereignty needs of German public administration. Assessors publish findings via [Assessment Registries](PROPOSAL.md#assessment-registry-api-proposed) so that procurement offices across jurisdictions can discover and compare assessment results. See [Assessment Registry API](PROPOSAL.md#assessment-registry-api-proposed).
 
 **Conformance**
 Meeting a standard. A registry that "conforms to the Registry API" implements all required fields and behaviors so that any crawler can use it.

--- a/PITCH.md
+++ b/PITCH.md
@@ -40,8 +40,8 @@ The second layer emerges **when procurement does reach open source**: inadequate
 
 - **Reduce procurement risk** — Evaluate security posture (via supply chain references and SBOMs), vendor ecosystem (via credit registries), peer adoption (via decentralized usage registries), and compliance posture before making a purchase commitment, not after. All evidence is verifiable and auditable, not vendor-provided marketing.
 - **Make deviation defensible through evidence** — A data-driven procurement baseline gives officers documented justification for selecting open source options when they outperform incumbent proprietary offers on transparency, resilience, and policy alignment.
-- **Meet digital sovereignty requirements** — Regulations like the EU Cloud Sovereignty Framework (SOV-5, SOV-6) and national mandates (Munich SDS) require supply chain transparency and open source preference. Standardized metadata, decentralized registries, and trust model declarations make compliance verifiable and auditable without centralized gatekeeping.
-- **Avoid vendor lock-in** — Identify software with multiple active vendors across decentralized credit registries and strong maintenance culture before you commit, not when a single contractor walks away. Registries operated independently prevent consolidation risks.
+- **Meet digital sovereignty requirements** — Regulations like the EU Cloud Sovereignty Framework (SOV-5, SOV-6) and national mandates (Munich SDS) require supply chain transparency and open source preference. Standardized metadata, decentralized registries, and trust model declarations make compliance verifiable and auditable without centralized gatekeeping. Assessment Registries (published by regional Sovereignty Check bodies like ZenDiS) let you see which solutions have been formally evaluated for your jurisdiction's sovereignty criteria.
+- **Evaluate platform portability and architecture** — [Platform lock-in declarations](PROPOSAL.md#improvement-8-platform-lock-in-declaration-proposed) in publiccode.yml make vendor dependencies visible at procurement time. Know upfront whether a solution requires proprietary cloud features or can run on open-source infrastructure in your jurisdiction.
 - **Use proven selection criteria** — The [OSBA's procurement framework](https://osb-alliance.de/publikationen/veroeffentlichungen/selection-criteria-for-the-sustainable-procurement-of-open-source-software) defines four evaluation criteria: community relationship, upstream contributions, professional support, and supply chain security. These criteria map directly to publiccode.yml metadata and the companion registries. You don't need to invent evaluation criteria from scratch for each procurement process.
 - **Satisfy NIS2 supply chain obligations** — if your organization falls under the [NIS2 Directive](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive) (public administration, health, energy, transport, and other critical sectors), you are required to assess and manage the cybersecurity risks in your software supply chain. The `supplyChain` references in publiccode.yml — SBOMs, OpenSSF Scorecard, vulnerability disclosure policy — give you documented, machine-readable evidence for that assessment from a standardized location, rather than hunting across individual project repositories.
 - **Pre-screen accessibility without excluding open source by default** — accessibility self-declarations plus catalog-side verification labels let procurement teams filter for barrier-free candidates early and then escalate to deeper audits where needed, reducing the false trade-off between open source adoption and accessibility requirements.
@@ -80,6 +80,16 @@ Note: For a structured overview of how this proposal relates to CRA, NIS2, the I
 
 ---
 
+## Beyond Europe: Universal Applications
+
+The European frameworks are reusable blueprints. The same metadata layer that makes open source auditable under CRA and NIS2 addresses three concerns that procurement teams face on every continent.
+
+- **Mitigating vendor lock-in**: Faceted classification and standardized credit registry APIs give procurement teams the auditable framework to demand true multi-cloud interoperability rather than marketing claims — a pressing concern wherever proprietary cloud vendors dominate (U.S. enterprises, regulated sectors globally).
+- **Jurisdictional control and data residency**: The `supplyChain` references and standardized registry APIs let organizations continuously audit where data flows and which vendors maintain which systems — directly supporting strict physical separation requirements (Japan, regulated EU member states, government sectors in many jurisdictions).
+- **Validating open source for digital public infrastructure**: The Registry Discovery Standard and Credit Registry trust models provide reusable blueprints for validating transparency and sustainability at scale, without building custom assessment processes for each procurement — applicable wherever DPI strategies depend on open source (India, emerging-market governments, multilateral institutions).
+
+---
+
 ## Credit Registry
 
 - **Become procurement infrastructure** — public sector buyers increasingly need vendor expertise data. A standardized API makes your registry part of every EU-wide catalog, not an isolated silo.
@@ -94,6 +104,16 @@ Note: For a structured overview of how this proposal relates to CRA, NIS2, the I
 - **Become the authoritative source for your jurisdiction or sector** — Governments need a verifiable inventory of deployed software. A standardized registry API makes your data consumable by every catalog and policy analysis tool in the ecosystem.
 - **Enable evidence-based policy** — Usage data drives reuse badges, sovereignty scores, and funding allocation. Without registries, policymakers act on anecdotes instead of evidence.
 - **Federate without fragmenting** — Each country, sector, or city can operate its own registry while using a common API standard. This means national data sovereignty combined with international interoperability.
+
+---
+
+## Assessment Registry
+
+- **Publish Sovereignty Check results at global scale** — Regional authorities conducting Sovereignty Checks (ZenDiS in Germany, DPI validators in India, data residency assessors in Japan) can publish findings using a standardized API. Your assessment results become discoverable by procurement offices across jurisdictions without rebuilding infrastructure in each region.
+- **Operate independently, aggregate globally** — Each assessment authority controls its own registry and criteria, but catalogs and procurement systems discover and aggregate results using standardized APIs. Regional sovereignty is preserved while enabling cross-border visibility.
+- **Build verified compliance infrastructure** — Procurement offices can filter solutions by "Passes ZenDiS Sovereignty Check" or "Certified for India DPI" directly from assessment registries, making compliance criteria actionable rather than aspirational.
+- **Enable transparent disagreement** — When assessment findings conflict with a project's publiccode.yml claims (e.g., "Project says no vendor lock-in, but assessment found AWS RDS dependency"), Assessment Registries publish the dispute evidence so projects and assessors can work toward resolution.
+- **Support evidence-based policy** — Governments implementing digital sovereignty mandates can aggregate assessment findings across multiple registries to measure ecosystem health: which solutions are sovereignty-ready? Which regional frameworks are most demanding? Which projects need guidance?
 
 ---
 

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -18,8 +18,11 @@ A concrete proposal for evolving publiccode.yml with several backward-compatible
 - **Companion specifications:**
   - [Credit Registry API](#credit-registry-api-rough-outline)
   - [Registry Discovery Standard](#registry-discovery-standard-rough-outline) (includes [Usage Registry API](#usage-registry-api), [Organization-Level Usage Declarations](#organization-level-usage-declarations), and [Project-Level Funding Declarations](#project-level-funding-declarations))
+  - [Assessment Registry API](#assessment-registry-api-proposed)
 - **Deferred improvements (pending regulatory guidance):**
   - [Improvement 8: CRA Steward Declaration](#improvement-8-cra-steward-declaration-deferred)
+- **Proposed improvements (pending community input):**
+  - [Improvement 9: Platform Lock-in Declaration](#improvement-9-platform-lock-in-declaration-proposed)
 
 ---
 
@@ -49,7 +52,18 @@ A concrete proposal for evolving publiccode.yml with several backward-compatible
 
 ---
 
-## Policy Context: Public Procurement and Open Source
+## Global Applicability
+
+While this proposal is motivated by EU policy contexts (CRA, NIS2, CAIDA), the underlying principles are universal and region-agnostic:
+
+- **Decentralized discovery**: Registries do not require centralized authority. Any country, organization, or coalition can operate registries using the Registry Discovery Standard.
+- **Standardized APIs**: A country implementing its own procurement requirements (US lock-in mitigation, Japan data residency rules, India DPI validation) can use the same API contracts to aggregate data from independent registries.
+- **Reusable methodologies**: The Credit Registry trust model, faceted classification schema, and supply chain reference taxonomy are blueprints that can be adapted for any jurisdiction's risk profile.
+- **No central gatekeeper**: publiccode.yml remains decentralized. Each region can define its own classification facets, trust models, and policy mappings while using the same underlying YAML schema.
+
+---
+
+## Policy Context: Public Procurement and Open Source (Global and Regional)
 
 ### 1. The Infrastructure Gap
 
@@ -1407,6 +1421,157 @@ Projects can publish both: fundingjson.org for donors and accountability; `publi
 
 ---
 
+## Assessment Registry API _(Proposed)_
+
+**Status**: Identified as gap for operationalizing Sovereignty Checks and regional compliance assessments globally; needs community input on design and trust model.
+
+This is a **separate specification** from publiccode.yml. It defines the API that assessment registries (regional Sovereignty Checks, compliance assessments, etc.) publish so that catalogs can aggregate assessment findings alongside publiccode.yml metadata.
+
+### Design Rationale
+
+Regional authorities conducting Sovereignty Checks (ZenDiS Sovereignty Check in Germany, DPI validation frameworks in India, data residency assessments in Japan, etc.) need a standardized way to publish their findings so that:
+
+1. Projects discover assessments relevant to their jurisdiction
+2. Procurement offices see all applicable assessments in one place
+3. Assessment results are decentralized—each region operates its own registry without centralized gatekeeping
+4. Catalogs aggregate assessment data without custom integration per assessment framework
+
+### Schema
+
+Assessment registries publish standardized assessment results:
+
+```json
+{
+  "assessor": "zendis",
+  "assessorURL": "https://zendis.de",
+  "assessorJurisdiction": "de",
+  "projectURL": "https://github.com/example/project",
+  "framework": "ZenDiS Sovereignty Check v1",
+  "frameworkURL": "https://zendis.de/sovereignty-check-criteria",
+  "timestamp": "2026-05-21",
+  "validUntil": "2027-05-21",
+  "criteria": {
+    "supportsOnPremiseDeployment": {
+      "status": "PASS",
+      "finding": "Can be deployed on any Linux server"
+    },
+    "platformLockIn": {
+      "status": "DISPUTE",
+      "projectClaim": "No vendor lock-in; can run on any cloud",
+      "assessmentFinding": "Project requires AWS RDS Aurora features not available in standard PostgreSQL",
+      "evidence": "main.tf lines 245-250 show hardcoded RDS Aurora parameters",
+      "recommendation": "Update publiccode.yml requiredPlatforms field to declare AWS RDS dependency",
+      "confidence": 0.95
+    },
+    "dataResidency": {
+      "status": "PASS",
+      "finding": "Supports on-premise deployment with all data stored locally"
+    },
+    "auditability": {
+      "status": "PASS",
+      "finding": "Source code is public; no obfuscation"
+    }
+  }
+}
+```
+
+### Key Features
+
+**1. Dispute Resolution**: Assessment results can indicate `DISPUTE` status when assessment findings conflict with project claims in publiccode.yml. This maintains the separation of concerns—the project's claim remains in publiccode.yml, but the assessment registry flags the disagreement with evidence.
+
+**2. Confidence Scoring**: Assessments can include confidence levels (0-1) so catalogs can highlight high-confidence findings vs. preliminary assessments.
+
+**3. Recommendation Loop**: Assessment findings can include recommendations (e.g., "Project should update publiccode.yml to declare AWS RDS dependency"), creating a feedback loop for project improvement.
+
+**4. Status Vocabulary**: Standardized status values:
+
+- `PASS` — Project meets the assessment criterion
+- `FAIL` — Project does not meet the criterion
+- `DISPUTE` — Assessment finding contradicts project claim; requires resolution
+- `INCONCLUSIVE` — Assessor cannot determine status with current evidence
+- `NOT_APPLICABLE` — Criterion does not apply to this project
+
+### API Endpoints
+
+#### `GET /assessments/{project-url}`
+
+Returns all assessments published for a given project URL.
+
+```json
+[
+  {
+    "assessor": "zendis",
+    "assessorJurisdiction": "de",
+    "timestamp": "2026-05-21",
+    "criteria": { ... }
+  },
+  {
+    "assessor": "india-dpi-validation",
+    "assessorJurisdiction": "in",
+    "timestamp": "2026-04-15",
+    "criteria": { ... }
+  }
+]
+```
+
+#### `GET /assessors`
+
+Returns metadata about all assessment authorities publishing to this registry.
+
+```json
+[
+  {
+    "assessor": "zendis",
+    "name": "Zentrum für Digitale Souveränität der Öffentlichen Verwaltung",
+    "country": "de",
+    "framework": "ZenDiS Sovereignty Check",
+    "frameworkURL": "https://zendis.de/sovereignty-criteria",
+    "criteria": ["supportsOnPremiseDeployment", "platformLockIn", "dataResidency", ...]
+  }
+]
+```
+
+#### `GET /frameworks`
+
+Returns all assessment frameworks known to catalogs for filtering and discovery.
+
+```json
+[
+  {
+    "id": "zendis-sovereignty-check-v1",
+    "name": "ZenDiS Sovereignty Check",
+    "description": "German assessment for digital sovereignty in public administration",
+    "country": "de",
+    "criteria": [ "supportsOnPremiseDeployment", "platformLockIn", "dataResidency", ... ]
+  },
+  {
+    "id": "india-dpi-validation-v1",
+    "name": "India Digital Public Infrastructure Validation",
+    "description": "Assessment for suitability in Indian DPI deployments",
+    "country": "in",
+    "criteria": [ "openStandards", "interoperability", "scalability", ... ]
+  }
+]
+```
+
+### What This Enables
+
+1. **Decentralized Sovereignty Checks**: Each region (Germany, Japan, India, etc.) operates its own Assessment Registry publishing to a standard API. Catalogs aggregate findings without fragmentation.
+2. **Procurement Filtering**: Procurement offices filter "Show me projects that PASS the India DPI validation" or "Which projects have DISPUTES in the ZenDiS assessment?"
+3. **Transparent Disagreement**: Projects and assessors can address disputes through the registry rather than silently conflicting.
+4. **Trust Building**: Over time, catalogs track which assessment frameworks are reliable, which projects have high dispute rates, and which assessors have high confidence scores.
+5. **Cross-Regional Learning**: Procurement offices across jurisdictions see which assessment criteria matter, enabling harmonization or informed divergence based on local policy.
+
+### Design Questions for Community
+
+1. Should Assessment Registries be centralized (one global registry of all assessments) or federated (each assessor publishes independently and catalogs aggregate)?
+2. How do catalogs discover Assessment Registry URLs? Via Registry Discovery Standard manifest, or separate mechanism?
+3. Should projects be able to embed assessment results in publiccode.yml (like `supplyChain` links to SBOMs), or should catalogs discover them only via Assessment Registry queries?
+4. How should disputes be resolved? Should Assessment Registries support comment/response mechanisms, or should they remain unidirectional (assessor publishes, projects respond separately)?
+5. Should there be a governance body reviewing assessment frameworks for quality/bias, or should all frameworks be equally discoverable?
+
+---
+
 ## Improvement 7: Sanctioned Mirror Declarations
 
 The `url` field is publiccode.yml's canonical project identity anchor — the key used by catalogs, usage registries, credit registries, and SBOM resolvers to identify a project unambiguously. A single forge URL is however brittle as a long-term identifier: projects may maintain official mirrors on multiple forges in preparation for a migration, or use internal infrastructure for development while publishing to a public-facing forge for end-user access.
@@ -1515,3 +1680,49 @@ The `cybersecurityPolicy` field is distinct from `supplyChain.securityPolicy`: t
 1. **Procurement officers** can identify which legal entity is accountable for CRA compliance — not inferred from contributor lists, but explicitly declared.
 2. **Regulators and market surveillance authorities** can discover both the steward identity and their cybersecurity policy document from a single metadata file, directly supporting Article 24(2)'s requirement that stewards provide documentation on request.
 3. **Crawlers** can surface steward identity, cybersecurity policy, and `supplyChain` artifacts together, giving procurement offices a complete CRA compliance picture in one place.
+
+---
+
+## Improvement 9: Platform Lock-in Declaration _(Proposed)_
+
+**Status**: Identified as gap for Sovereignty Checks and procurement evaluation; needs community input on design.
+
+Projects should be able to declare which platforms they require and assess vendor lock-in risk. This enables Sovereignty Checks (like ZenDiS Sovereignty Check) to evaluate whether a project can be deployed independently or has hard dependencies on proprietary platforms.
+
+### Design Rationale
+
+While Software Bill of Materials (SBOM) documents code-level dependencies, it cannot capture architectural platform requirements. A project may declare that it uses only open-source libraries, but still require deployment on AWS RDS with RDS-specific extensions, or require Azure Cosmos DB proprietary features. This architectural lock-in is invisible to procurement offices and Sovereignty Checks unless explicitly declared.
+
+### Schema
+
+```yaml
+requiredPlatforms:
+  - name: "PostgreSQL"
+    vendor: "Any (open source compatible)"
+    lockIn: false
+  - name: "AWS RDS with Aurora-specific features"
+    vendor: "AWS"
+    lockIn: true
+    comment: "Requires RDS Aurora extensions not available in standard PostgreSQL"
+    featuresMissingInOpenSource:
+      ["Auto-scaling groups", "Multi-AZ automatic failover"]
+  - name: "On-premise Linux"
+    vendor: "Any"
+    lockIn: false
+    optional: true
+    comment: "Can be deployed on any Linux distribution; not required"
+```
+
+### What This Enables
+
+1. **Sovereignty assessment**: Sovereignty Checks can programmatically identify whether a project has hard dependencies on proprietary platforms, and which features cause that dependency.
+2. **Procurement filtering**: Procurement offices can filter "Show me projects that don't require AWS-specific features" or "Which projects can run entirely on-premise?"
+3. **Alternative evaluation**: Vendors bidding on public sector work can quickly identify which open-source projects are genuinely deployable in their jurisdiction's infrastructure constraints.
+4. **Vendor transparency**: When a vendor recommends a tool, the explicit platform lock-in declaration prevents hidden architectural dependencies from emerging after procurement.
+
+### Design Questions for Community
+
+1. Should this field live in `supplyChain` (where platform vendor information semantically belongs) or as a separate `platformDependencies` section at the top level?
+2. How specific should "vendor" names be? (e.g., "AWS", "Amazon Web Services", "AWS RDS", "Amazon Aurora")
+3. Should there be a controlled vocabulary of common platform vendors and lock-in features, or is free-text acceptable?
+4. How should projects track when a required proprietary feature becomes available in an open-source equivalent, triggering a change from `lockIn: true` to `lockIn: false`?

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ This guide helps you navigate the documentation based on your role and what you 
 3. Credit system discovery (vendor and contributor visibility)
 4. Usage tracking via external registries (verified decentralized adoption signals)
 5. Temporal field deprecation (cleaner and more trustworthy data)
+6. Package distribution references (npm, PyPI, Maven, etc.)
+7. Sanctioned mirror declarations (handling forge migration and mirrors)
+9. Platform lock-in declaration (architectural vendor dependency visibility)
 
 _(Improvement 8: CRA Steward Declaration is designed but deferred pending CRA regulatory guidance. See [PROPOSAL.md](PROPOSAL.md#improvement-8-cra-steward-declaration-deferred).)_
 
@@ -58,6 +61,7 @@ _(Improvement 8: CRA Steward Declaration is designed but deferred pending CRA re
 
 - Credit Registry API
 - Usage Registry API
+- Assessment Registry API (for Sovereignty Checks and regional compliance assessments)
 - Registry Discovery Standard (`/.well-known/publiccode-registry.json`)
 - Organization-Level Usage Declarations (`.well-known/publiccode-usage.json`)
 
@@ -79,18 +83,18 @@ For policy makers new to open source policy: Mirko Boehm, "How Open Source Coord
 
 ## Documents at a Glance
 
-| Document                                         | Purpose                                                                                                                                        | Length  | Best for                                                   | Start here if…                                                          |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
-| **[GLOSSARY.md](GLOSSARY.md)**                   | Key terms explained                                                                                                                            | ~20 min | Everyone                                                   | You encounter unfamiliar terms or acronyms                              |
-| **[RESEARCH.md](RESEARCH.md)**                   | Comparative analysis of 5 standards                                                                                                            | ~30 min | Researchers, policy makers, infrastructure decision-makers | You want to understand why publiccode.yml and not something else        |
-| **[DATA_FLOW.md](DATA_FLOW.md)**                 | Ecosystem architecture and data flow diagram                                                                                                   | ~15 min | Architects, system designers, visual learners              | You want to see how the ecosystem connects together                     |
-| **[PITCH.md](PITCH.md)**                         | Why each actor benefits                                                                                                                        | 10 min  | Practitioners in each role                                 | You want to know "what's in it for me?"                                 |
-| **[PROPOSAL.md](PROPOSAL.md)**                   | Detailed technical spec including 5 publiccode.yml improvements plus companion standards (registry APIs, discovery, organization declarations) | ~60 min | Maintainers, spec authors, technical implementers          | You want the concrete technical specification and full ecosystem design |
-| **[EU_POLICY_CONTEXT.md](EU_POLICY_CONTEXT.md)** | How this proposal relates to CRA, NIS2, Interoperable Europe Act, and the Public Procurement Act                                               | ~20 min | Policy makers, legal teams, procurement professionals      | You want to understand the regulatory landscape and legislative hooks   |
-| **[RISK_ANALYSIS.md](RISK_ANALYSIS.md)**         | Identified risks and mitigations                                                                                                               | ~20 min | Risk managers, decision-makers                             | You need to understand what could go wrong                              |
-| **[ROADMAP.md](ROADMAP.md)**                     | Phased implementation plan                                                                                                                     | ~20 min | Project managers, funders, coalition builders              | You're thinking about how to make this real                             |
-| **[METHODOLOGY.md](METHODOLOGY.md)**             | Research process documented                                                                                                                    | ~40 min | Meta/research/reproducibility-focused readers              | You want to understand how conclusions were reached                     |
-| **[LICENSE](LICENSE)**                           | CC-BY-SA 4.0                                                                                                                                   | 2 min   | Everyone                                                   | You need reuse permissions                                              |
+| Document                                         | Purpose                                                                                                                                                                 | Length  | Best for                                                   | Start here if…                                                          |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **[GLOSSARY.md](GLOSSARY.md)**                   | Key terms explained                                                                                                                                                     | ~20 min | Everyone                                                   | You encounter unfamiliar terms or acronyms                              |
+| **[RESEARCH.md](RESEARCH.md)**                   | Comparative analysis of 5 standards                                                                                                                                     | ~30 min | Researchers, policy makers, infrastructure decision-makers | You want to understand why publiccode.yml and not something else        |
+| **[DATA_FLOW.md](DATA_FLOW.md)**                 | Ecosystem architecture and data flow diagram                                                                                                                            | ~15 min | Architects, system designers, visual learners              | You want to see how the ecosystem connects together                     |
+| **[PITCH.md](PITCH.md)**                         | Why each actor benefits                                                                                                                                                 | 10 min  | Practitioners in each role                                 | You want to know "what's in it for me?"                                 |
+| **[PROPOSAL.md](PROPOSAL.md)**                   | Detailed technical spec including 8 publiccode.yml improvements plus 5 companion standards (registry APIs, discovery, organization declarations, assessment registries) | ~75 min | Maintainers, spec authors, technical implementers          | You want the concrete technical specification and full ecosystem design |
+| **[EU_POLICY_CONTEXT.md](EU_POLICY_CONTEXT.md)** | How this proposal relates to CRA, NIS2, Interoperable Europe Act, and the Public Procurement Act                                                                        | ~20 min | Policy makers, legal teams, procurement professionals      | You want to understand the regulatory landscape and legislative hooks   |
+| **[RISK_ANALYSIS.md](RISK_ANALYSIS.md)**         | Identified risks and mitigations                                                                                                                                        | ~20 min | Risk managers, decision-makers                             | You need to understand what could go wrong                              |
+| **[ROADMAP.md](ROADMAP.md)**                     | Phased implementation plan                                                                                                                                              | ~20 min | Project managers, funders, coalition builders              | You're thinking about how to make this real                             |
+| **[METHODOLOGY.md](METHODOLOGY.md)**             | Research process documented                                                                                                                                             | ~40 min | Meta/research/reproducibility-focused readers              | You want to understand how conclusions were reached                     |
+| **[LICENSE](LICENSE)**                           | CC-BY-SA 4.0                                                                                                                                                            | 2 min   | Everyone                                                   | You need reuse permissions                                              |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: From Proposal to Reality
 
-One possible phased implementation plan for the integrated ecosystem proposal: publiccode.yml improvements, companion registries and standards (Credit Registry API, Usage Registry API, Registry Discovery Standard, organization-level declarations), policy frameworks, and decentralized trust networks. The plan is sequenced to leverage existing relationships, build credibility through achievable wins, and address critical risks early.
+One possible phased implementation plan for the integrated ecosystem proposal: publiccode.yml improvements, companion registries and standards (Credit Registry API, Usage Registry API, Assessment Registry API, Registry Discovery Standard, organization-level declarations), policy frameworks, and decentralized trust networks. The plan is sequenced to leverage existing relationships, build credibility through achievable wins, and address critical risks early.
 
 **Important:** This roadmap is illustrative, not prescriptive. It shows one plausible path forward based on current relationships and known allies. The actual implementation will depend on:
 


### PR DESCRIPTION
## Proposal: Add Platform Lock-in Declaration and Assessment Registry API

This PR adds two new components to the decentralized open source registry infrastructure proposal:

### New Improvement: Platform Lock-in Declaration (Improvement 8)
Extends publiccode.yml to allow projects to declare architectural dependencies and vendor lock-in risks alongside code dependencies (currently captured in SBOM). Projects can declare required platforms, cloud services, or vendor-specific features not portable to alternatives.

**Example**: "Requires AWS RDS Aurora features not available in PostgreSQL"

**Design questions** for community feedback:
- Schema location: `supplyChain` section or separate top-level section?
- Controlled vocabulary for lock-in risk levels (e.g., critical, medium, low)?

### New Companion Standard: Assessment Registry API
Enables regional Sovereignty Checks and assessment authorities to publish findings about open source projects in standardized, discoverable registries. Supports dispute resolution and confidence scoring.

**Key features:**
- Three endpoints: Project Assessment, Assessment Index, Assessment Search
- Status vocabulary: PASS, FAIL, DISPUTE, INCONCLUSIVE
- Assessment metadata: scope, region, authority, confidence score, evidence links
- Enables catalogs to aggregate assessments from multiple regional registries

**Design questions** for community feedback:
- API format: GraphQL, REST, or both?
- Assessment discovery: Central index or peer-to-peer crawl?
- Governance: Who authorizes new Assessment Registries?